### PR TITLE
Remove zig installation from release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -89,15 +89,6 @@ jobs:
           go-version: ${{ env.GO_VERSION }}
           cache-dependency-path: "**/*.sum"
 
-      - name: Install zig
-        run: |
-          SIGNATURE="2d00e789fec4f71790a6e7bf83ff91d564943c5ee843c5fd966efc474b423047  zig-linux-x86_64-0.11.0.tar.xz"
-          curl -sSfL https://ziglang.org/download/0.11.0/zig-linux-x86_64-0.11.0.tar.xz -o zig-linux-x86_64-0.11.0.tar.xz
-          echo $SIGNATURE | sha256sum -c
-          tar -xf zig-linux-x86_64-0.11.0.tar.xz
-          sudo ln -s $PWD/zig-linux-x86_64-0.11.0/zig /usr/local/bin/zig
-          zig version
-
       - name: Install Python dependencies
         run: |
           pip install --upgrade pip


### PR DESCRIPTION
# Description
This update removes the Zig installation step from the GitHub Actions release workflow.

# Changes
- Removed the step for installing Zig in the GitHub Actions release workflow.